### PR TITLE
adds 2026 toggle for nominal code changes

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -32,6 +32,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 function populateTrialBalance(params) {
   const {
     includeBF,
+    codeFilter2026,
     minValue,
     maxValue,
     postingType,
@@ -53,9 +54,11 @@ function populateTrialBalance(params) {
   if (!includeBF) {
     inputRows = inputRows.filter(checkNotBF);
   }
+
+  inputRows = inputRows.filter((inputRow) => checkYearSpecificCodeFilter(inputRow, codeFilter2026));
   
   if (inputRows.length === 0) {
-    throw new Error("No eligible rows to populate after filtering. Try enabling 'Include brought forward accounts'.");
+    throw new Error("No eligible rows to populate after filtering. Try enabling brought forward accounts or switching the 2026 onwards setting.");
   }
 
   if (parsedDensity < 100) {
@@ -136,6 +139,51 @@ function checkNotBF(inputRow) {
 
   // Check if the account name contains any of the excluded terms
   return !excludedTerms.test(account_name);
+}
+
+const POST_2026_CODES = new Set(['1040', '1113', '2241', '2267', '2268', '2641', '2667', '7704', '7705', '7706', '7907']);
+const PRE_2026_CODES = new Set(['1170', '2240', '2640', '7703', '7904', '7906']);
+
+function checkYearSpecificCodeFilter(inputRow, use2026OnwardsCodes) {
+  const accountCode = getAccountCodeFromRow(inputRow);
+  if (!accountCode) {
+    return true;
+  }
+
+  if (use2026OnwardsCodes) {
+    return !PRE_2026_CODES.has(accountCode);
+  }
+
+  return !POST_2026_CODES.has(accountCode);
+}
+
+function getAccountCodeFromRow(inputRow) {
+  const codeSelectors = [
+    '.nominal_account_code',
+    '[class*="nominal_account_code"]',
+    '[class*="account_code"]',
+    '[data-account-code]',
+    '[data-nominal-code]'
+  ];
+
+  for (const selector of codeSelectors) {
+    const codeElement = inputRow.querySelector(selector);
+    const code = extractFourDigitCode(codeElement && (codeElement.innerText || codeElement.textContent || codeElement.getAttribute('data-account-code') || codeElement.getAttribute('data-nominal-code')));
+    if (code) {
+      return code;
+    }
+  }
+
+  return extractFourDigitCode(inputRow.innerText || inputRow.textContent);
+}
+
+function extractFourDigitCode(value) {
+  if (!value) {
+    return null;
+  }
+
+  const match = value.match(/\b([0-9]{4})\b/);
+  return match ? match[1] : null;
 }
 
 function shuffleArray(array) {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Pop TB",
   "description": "Fully populate an Initial or Comparative Trial Balance in Final Accounts Online.",
-  "version": "1.1",
+  "version": "1.2",
   "author": "Charlie Billen, Mark Kirkham",
 
   "icons": {

--- a/chrome/popup.css
+++ b/chrome/popup.css
@@ -368,7 +368,7 @@ body {
 
 .help-tooltip {
   position: absolute;
-  bottom: calc(100% + 8px);
+  top: calc(100% + 8px);
   left: 50%;
   transform: translateX(-50%);
   background: var(--color-tooltip-bg);
@@ -379,7 +379,8 @@ body {
   letter-spacing: normal;
   padding: 10px 12px;
   border-radius: 8px;
-  width: 220px;
+  width: 280px;
+  max-width: min(280px, calc(100vw - 32px));
   line-height: 1.5;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
   opacity: 0;
@@ -392,11 +393,11 @@ body {
 .help-tooltip::after {
   content: '';
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
   border: 6px solid transparent;
-  border-top-color: var(--color-tooltip-bg);
+  border-bottom-color: var(--color-tooltip-bg);
 }
 
 .help-icon:hover .help-tooltip,

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -66,13 +66,20 @@
           <h3 class="card-title" id="optionsTitle">
             Options
             <span class="help-icon" tabindex="0" role="button" aria-label="Help: Additional settings for populating the trial balance">
-              <span class="help-tooltip">Brought forward accounts are opening balances from previous periods. Enable to include them in population.</span>
+              <span class="help-tooltip">Brought forward accounts are opening balances from previous periods. Use the 2026 onwards toggle to choose which nominal code set applies.</span>
             </span>
           </h3>
           <div class="toggle-wrapper">
             <span class="toggle-label" id="includeBFLabel">Include brought forward accounts</span>
             <label class="toggle-switch">
               <input type="checkbox" id="chkIncludeBF" name="includeBF" role="switch" aria-labelledby="includeBFLabel">
+              <span class="toggle-slider" aria-hidden="true"></span>
+            </label>
+          </div>
+          <div class="toggle-wrapper">
+            <span class="toggle-label" id="codeFilter2026Label">Use 2026 onwards codes</span>
+            <label class="toggle-switch">
+              <input type="checkbox" id="chkCodeFilter2026" name="codeFilter2026" role="switch" aria-labelledby="codeFilter2026Label">
               <span class="toggle-slider" aria-hidden="true"></span>
             </label>
           </div>

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -84,6 +84,7 @@ window.onload = function () {
   const defaultPrefs = {
     postingType: 'both',
     includeBF: false,
+    codeFilter2026: true,
     minValue: '1',
     maxValue: '9999',
     density: '100'
@@ -107,6 +108,7 @@ window.onload = function () {
 
     // Apply include BF
     document.getElementById("chkIncludeBF").checked = prefs.includeBF;
+    document.getElementById("chkCodeFilter2026").checked = prefs.codeFilter2026 !== false;
 
     // Apply min/max values
     document.getElementById("numMinValue").value = prefs.minValue;
@@ -124,6 +126,7 @@ window.onload = function () {
     const prefs = {
       postingType: document.querySelector('input[name="postingType"]:checked').value,
       includeBF: document.getElementById("chkIncludeBF").checked,
+      codeFilter2026: document.getElementById("chkCodeFilter2026").checked,
       minValue: document.getElementById("numMinValue").value,
       maxValue: document.getElementById("numMaxValue").value,
       density: document.getElementById("rngDensity").value
@@ -259,11 +262,19 @@ window.onload = function () {
       const tab = tabs[0];
       const postingType = document.querySelector('input[name="postingType"]:checked').value,
         includeBF = document.getElementById("chkIncludeBF").checked,
+        codeFilter2026 = document.getElementById("chkCodeFilter2026").checked,
         minValue = document.getElementById("numMinValue").value,
         maxValue = document.getElementById("numMaxValue").value,
         density = document.getElementById("rngDensity").value;
 
-      const params = { "postingType": postingType, "includeBF": includeBF, "minValue": minValue, "maxValue": maxValue, "density": density };
+      const params = {
+        postingType: postingType,
+        includeBF: includeBF,
+        codeFilter2026: codeFilter2026,
+        minValue: minValue,
+        maxValue: maxValue,
+        density: density
+      };
 
       chrome.tabs.sendMessage(tab.id, { action: "populateTB", params: params }, function (response) {
         // Must check lastError first to suppress the console error

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -30,6 +30,7 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 function populateTrialBalance(params) {
   const {
     includeBF,
+    codeFilter2026,
     minValue,
     maxValue,
     postingType,
@@ -51,9 +52,11 @@ function populateTrialBalance(params) {
   if (!includeBF) {
     inputRows = inputRows.filter(checkNotBF);
   }
+
+  inputRows = inputRows.filter((inputRow) => checkYearSpecificCodeFilter(inputRow, codeFilter2026));
   
   if (inputRows.length === 0) {
-    throw new Error("No eligible rows to populate after filtering. Try enabling 'Include brought forward accounts'.");
+    throw new Error("No eligible rows to populate after filtering. Try enabling brought forward accounts or switching the 2026 onwards setting.");
   }
 
   if (parsedDensity < 100) {
@@ -134,6 +137,51 @@ function checkNotBF(inputRow) {
 
   // Check if the account name contains any of the excluded terms
   return !excludedTerms.test(account_name);
+}
+
+const POST_2026_CODES = new Set(['1040', '1113', '2241', '2267', '2268', '2641', '2667', '7704', '7705', '7706', '7907']);
+const PRE_2026_CODES = new Set(['1170', '2240', '2640', '7703', '7904', '7906']);
+
+function checkYearSpecificCodeFilter(inputRow, use2026OnwardsCodes) {
+  const accountCode = getAccountCodeFromRow(inputRow);
+  if (!accountCode) {
+    return true;
+  }
+
+  if (use2026OnwardsCodes) {
+    return !PRE_2026_CODES.has(accountCode);
+  }
+
+  return !POST_2026_CODES.has(accountCode);
+}
+
+function getAccountCodeFromRow(inputRow) {
+  const codeSelectors = [
+    '.nominal_account_code',
+    '[class*="nominal_account_code"]',
+    '[class*="account_code"]',
+    '[data-account-code]',
+    '[data-nominal-code]'
+  ];
+
+  for (const selector of codeSelectors) {
+    const codeElement = inputRow.querySelector(selector);
+    const code = extractFourDigitCode(codeElement && (codeElement.innerText || codeElement.textContent || codeElement.getAttribute('data-account-code') || codeElement.getAttribute('data-nominal-code')));
+    if (code) {
+      return code;
+    }
+  }
+
+  return extractFourDigitCode(inputRow.innerText || inputRow.textContent);
+}
+
+function extractFourDigitCode(value) {
+  if (!value) {
+    return null;
+  }
+
+  const match = value.match(/\b([0-9]{4})\b/);
+  return match ? match[1] : null;
 }
 
 function shuffleArray(array) {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Pop TB",
   "description": "Fully populate an Initial or Comparative Trial Balance in Final Accounts Online.",
-  "version": "1.1",
+  "version": "1.2",
   "author": "Charlie Billen, Mark Kirkham",
 
   "browser_specific_settings": {

--- a/firefox/popup.css
+++ b/firefox/popup.css
@@ -368,7 +368,7 @@ body {
 
 .help-tooltip {
   position: absolute;
-  bottom: calc(100% + 8px);
+  top: calc(100% + 8px);
   left: 50%;
   transform: translateX(-50%);
   background: var(--color-tooltip-bg);
@@ -379,7 +379,8 @@ body {
   letter-spacing: normal;
   padding: 10px 12px;
   border-radius: 8px;
-  width: 220px;
+  width: 280px;
+  max-width: min(280px, calc(100vw - 32px));
   line-height: 1.5;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
   opacity: 0;
@@ -392,11 +393,11 @@ body {
 .help-tooltip::after {
   content: '';
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
   border: 6px solid transparent;
-  border-top-color: var(--color-tooltip-bg);
+  border-bottom-color: var(--color-tooltip-bg);
 }
 
 .help-icon:hover .help-tooltip,

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -66,13 +66,20 @@
           <h3 class="card-title" id="optionsTitle">
             Options
             <span class="help-icon" tabindex="0" role="button" aria-label="Help: Additional settings for populating the trial balance">
-              <span class="help-tooltip">Brought forward accounts are opening balances from previous periods. Enable to include them in population.</span>
+              <span class="help-tooltip">Brought forward accounts are opening balances from previous periods. Use the 2026 onwards toggle to choose which nominal code set applies.</span>
             </span>
           </h3>
           <div class="toggle-wrapper">
             <span class="toggle-label" id="includeBFLabel">Include brought forward accounts</span>
             <label class="toggle-switch">
               <input type="checkbox" id="chkIncludeBF" name="includeBF" role="switch" aria-labelledby="includeBFLabel">
+              <span class="toggle-slider" aria-hidden="true"></span>
+            </label>
+          </div>
+          <div class="toggle-wrapper">
+            <span class="toggle-label" id="codeFilter2026Label">Use 2026 onwards codes</span>
+            <label class="toggle-switch">
+              <input type="checkbox" id="chkCodeFilter2026" name="codeFilter2026" role="switch" aria-labelledby="codeFilter2026Label">
               <span class="toggle-slider" aria-hidden="true"></span>
             </label>
           </div>

--- a/firefox/popup.js
+++ b/firefox/popup.js
@@ -86,6 +86,7 @@ window.onload = function () {
   const defaultPrefs = {
     postingType: 'both',
     includeBF: false,
+    codeFilter2026: true,
     minValue: '1',
     maxValue: '9999',
     density: '100'
@@ -111,6 +112,7 @@ window.onload = function () {
 
     // Apply include BF
     document.getElementById("chkIncludeBF").checked = prefs.includeBF;
+    document.getElementById("chkCodeFilter2026").checked = prefs.codeFilter2026 !== false;
 
     // Apply min/max values
     document.getElementById("numMinValue").value = prefs.minValue;
@@ -128,6 +130,7 @@ window.onload = function () {
     const prefs = {
       postingType: document.querySelector('input[name="postingType"]:checked').value,
       includeBF: document.getElementById("chkIncludeBF").checked,
+      codeFilter2026: document.getElementById("chkCodeFilter2026").checked,
       minValue: document.getElementById("numMinValue").value,
       maxValue: document.getElementById("numMaxValue").value,
       density: document.getElementById("rngDensity").value
@@ -250,11 +253,19 @@ window.onload = function () {
       const tab = tabs[0];
       const postingType = document.querySelector('input[name="postingType"]:checked').value,
         includeBF = document.getElementById("chkIncludeBF").checked,
+        codeFilter2026 = document.getElementById("chkCodeFilter2026").checked,
         minValue = document.getElementById("numMinValue").value,
         maxValue = document.getElementById("numMaxValue").value,
         density = document.getElementById("rngDensity").value;
 
-      const params = { "postingType": postingType, "includeBF": includeBF, "minValue": minValue, "maxValue": maxValue, "density": density };
+      const params = {
+        postingType: postingType,
+        includeBF: includeBF,
+        codeFilter2026: codeFilter2026,
+        minValue: minValue,
+        maxValue: maxValue,
+        density: density
+      };
 
       browser.tabs.sendMessage(tab.id, { action: "populateTB", params: params }).then(function (response) {
         handleResponse(response, "Trial Balance populated successfully!", 'populate');


### PR DESCRIPTION
Several nominals are no longer relevant for SOA commencing 1st Jan 26 or later and should not be posted to. There are new codes that are not relevant for pre-2026 also. If they are there will be a blocking validation. Added a toggle to avoid posting to these codes for pre and post depending on you commencement date. Updated Chrome and Firefox and version to 1.2